### PR TITLE
Update SEGFacebookAppEventsIntegrationFactory.m key

### DIFF
--- a/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.m
+++ b/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.m
@@ -26,7 +26,7 @@
 
 - (NSString *)key
 {
-    return @"Facebook";
+    return @"Facebook App Events";
 }
 
 @end


### PR DESCRIPTION
When Segment iOS SDK is initialised and receives the API settings response, the key for this  integration is "Facebook App Events" not "Facebook".

This causes this integration not to be correctly initialised in: `- (void)updateIntegrationsWithSettings:(NSDictionary *)projectSettings`.

Simply changing this key fixes this issue, allowing the integration to be correctly set up and all events tracked and the `[FBSDKAppEvents activateApp];` call to be made on didBecomeActive.