### PR TITLE
updates analytics to 3.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - FBSDKCoreKit (4.10.1):
     - Bolts (~> 1.5)
   - Segment-Facebook-App-Events (1.0.1):
-    - Analytics (~> 3.0.0)
+    - Analytics (~> 3.0)
     - FBSDKCoreKit (~> 4.10.1)
   - Specta (1.0.5)
 
@@ -21,14 +21,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Segment-Facebook-App-Events:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   FBSDKCoreKit: d2aaed5e9ab7d8d6301c533376a1fbff1cf3deb5
-  Segment-Facebook-App-Events: b03c1074997f2711c34731f37935be5109cf70c2
+  Segment-Facebook-App-Events: afd05dd84b1c8dcb5e0c011891fa9f3a5c373967
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 PODFILE CHECKSUM: 35fb1c6294136db9b99cbeeb196e53f8fad6f1d9

--- a/Example/Pods/Local Podspecs/Segment-Facebook-App-Events.podspec.json
+++ b/Example/Pods/Local Podspecs/Segment-Facebook-App-Events.podspec.json
@@ -22,7 +22,7 @@
   "source_files": "Pod/Classes/**/*",
   "dependencies": {
     "Analytics": [
-      "~> 3.0.0"
+      "~> 3.0"
     ],
     "FBSDKCoreKit": [
       "~> 4.10.1"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -10,7 +10,7 @@ PODS:
   - FBSDKCoreKit (4.10.1):
     - Bolts (~> 1.5)
   - Segment-Facebook-App-Events (1.0.1):
-    - Analytics (~> 3.0.0)
+    - Analytics (~> 3.0)
     - FBSDKCoreKit (~> 4.10.1)
   - Specta (1.0.5)
 
@@ -21,14 +21,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Segment-Facebook-App-Events:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   FBSDKCoreKit: d2aaed5e9ab7d8d6301c533376a1fbff1cf3deb5
-  Segment-Facebook-App-Events: b03c1074997f2711c34731f37935be5109cf70c2
+  Segment-Facebook-App-Events: afd05dd84b1c8dcb5e0c011891fa9f3a5c373967
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 PODFILE CHECKSUM: 35fb1c6294136db9b99cbeeb196e53f8fad6f1d9

--- a/Segment-Facebook-App-Events.podspec
+++ b/Segment-Facebook-App-Events.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.0.0'
+  s.dependency 'Analytics', '~> 3.0'
   s.dependency 'FBSDKCoreKit', '~> 4.10.1'
 
   s.pod_target_xcconfig = { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }


### PR DESCRIPTION
There is a conflict between the AppsFlyer and Facebook libraries:

- `Analytics (~> 3.1.0)` required by `segment-appsflyer-ios (1.0.0)`

- `Analytics (~> 3.0.0)` required by `Segment-Facebook-App-Events (1.0.0)`

This should allow users to use 3.0 > 4.0 
