### PR TITLE
Implement data processing overrides

### DIFF
--- a/Example/Segment-Facebook/SEGAppDelegate.m
+++ b/Example/Segment-Facebook/SEGAppDelegate.m
@@ -18,8 +18,15 @@
     [SEGAnalytics debug:YES];
     SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"gnjyuUpq7mZYtLM76mwltoiZcDsFpnfY"];
     
-    // Add any of your bundled integrations.
-    [config use:[SEGFacebookAppEventsIntegrationFactory instance]];
+    // Init the FB integration SDK
+    SEGFacebookAppEventsIntegrationFactory *fb = [SEGFacebookAppEventsIntegrationFactory instance];
+
+    // Optional - Set the data processing options to override the default options of
+    // [['LDU'], 0, 0]
+    //    [fb setDataProcessingOptions:@[ @"UDL" ] forCountry:99 forState: 99];
+
+    // Add the bundle FB integration SDK
+    [config use:fb];
     
     [SEGAnalytics setupWithConfiguration:config];
     

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.h
@@ -4,7 +4,10 @@
 @interface SEGFacebookAppEventsIntegration : NSObject<SEGIntegration>
 
 @property(nonatomic, strong) NSDictionary *settings;
+@property(nonatomic, strong) NSArray<NSString *> *dataProcessingOptions;
+@property(nonatomic) int *dataProcessingCountry;
+@property(nonatomic) int *dataProcessingState;
 
-- (id)initWithSettings:(NSDictionary *)settings;
+- (id)initWithSettings:(NSDictionary *)settings dataProcessingOptions:(NSArray<NSString *> *)options dataProcessingCountry:(int *)country dataProcessingState:(int *)state;
 
 @end

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.m
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.m
@@ -6,20 +6,27 @@
 
 #pragma mark - Initialization
 
-- (id)initWithSettings:(NSDictionary *)settings
+- (id)initWithSettings:(NSDictionary *)settings dataProcessingOptions:(NSArray<NSString *> *)options dataProcessingCountry:(int *)country dataProcessingState:(int *)state
 {
     if (self = [super init]) {
         self.settings = settings;
+        self.dataProcessingOptions = options;
+        self.dataProcessingCountry = country;
+        self.dataProcessingState = state;
         
         NSString *appId = [settings objectForKey:@"appId"];
         [FBSDKSettings setAppID:appId];
 
         if ([(NSNumber *)self.settings[@"limitedDataUse"] boolValue]) {
-            [FBSDKSettings setDataProcessingOptions:@[@"LDU"] country:0 state:0]; 
-            SEGLog(@"[FBSDKSettings setDataProcessingOptions:['LDU'] country:0 state:0");
+            NSArray<NSString *> *options = self.dataProcessingOptions ? self.dataProcessingOptions : @[@"LDU"];
+            int *country = self.dataProcessingCountry ? self.dataProcessingCountry : 0;
+            int *state = self.dataProcessingState ? self.dataProcessingState : 0;
+
+            [FBSDKSettings setDataProcessingOptions:options country:country state:state]; 
+            SEGLog(@"[FBSDKSettings setDataProcessingOptions:[%@] country:%d state:%d", [options componentsJoinedByString:@","], country, state);
         } else {
-            SEGLog(@"[FBSDKSettings setDataProcessingOptions:[]");
             [FBSDKSettings setDataProcessingOptions:@[]];
+            SEGLog(@"[FBSDKSettings setDataProcessingOptions:[]");
         }
     }
     return self;

--- a/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
@@ -5,4 +5,10 @@
 
 + (instancetype)instance;
 
+@property(nonatomic, strong) NSArray<NSString *> *dataProcessingOptions;
+@property(nonatomic) int *dataProcessingCountry;
+@property(nonatomic) int *dataProcessingState;
+
+- (id)setDataProcessingOptions:(NSArray<NSString *> *)options forCountry:(int *)country forState:(int *)state;
+
 @end

--- a/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.m
+++ b/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.m
@@ -19,9 +19,20 @@
     return self;
 }
 
+- (id)setDataProcessingOptions:(NSArray<NSString *> *)options forCountry:(int *)country forState:(int *)state
+{
+    self.dataProcessingOptions = options;
+    self.dataProcessingCountry = country;
+    self.dataProcessingState = state;
+    return self;
+}
+
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGFacebookAppEventsIntegration alloc] initWithSettings:settings];
+    return [[SEGFacebookAppEventsIntegration alloc] initWithSettings:settings
+                                                    dataProcessingOptions:self.dataProcessingOptions
+                                                    dataProcessingCountry:self.dataProcessingCountry
+                                                    dataProcessingState:self.dataProcessingState];
 }
 
 - (NSString *)key


### PR DESCRIPTION
> This is a follow up to #21. 

Implements data processing overrides that can be set when creating an instance of the integration SDK. For example:
```
    // Init the FB integration SDK
    SEGFacebookAppEventsIntegrationFactory *fb = [SEGFacebookAppEventsIntegrationFactory instance];

    // Optional - Set the data processing options to override the default options of
    // [['LDU'], 0, 0]
    [fb setDataProcessingOptions:@[ @"UDL" ] forCountry:99 forState: 99];

    // Add the bundle FB integration SDK
    [config use:fb];
```

If data processing options are not set, we'll default to the parameters: `['LDU'], 0, 0`