### PR TITLE
[STRATCONN-419] Update namespacing for ios14 

### DIFF
--- a/Example/Segment-Facebook/SEGAppDelegate.m
+++ b/Example/Segment-Facebook/SEGAppDelegate.m
@@ -7,7 +7,7 @@
 //
 
 #import "SEGAppDelegate.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>

--- a/Example/Segment-Facebook/SEGAppDelegate.m
+++ b/Example/Segment-Facebook/SEGAppDelegate.m
@@ -7,7 +7,11 @@
 //
 
 #import "SEGAppDelegate.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
 #import <Segment-Facebook-App-Events/SEGFacebookAppEventsIntegrationFactory.h>
 
 @implementation SEGAppDelegate

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #else
 #import <Segment/SEGIntegration.h>

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
 
 @interface SEGFacebookAppEventsIntegration : NSObject<SEGIntegration>
 

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.m
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.m
@@ -1,7 +1,7 @@
 #import "SEGFacebookAppEventsIntegration.h"
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
 #else
 #import <Segment/SEGAnalyticsUtils.h>

--- a/Pod/Classes/SEGFacebookAppEventsIntegration.m
+++ b/Pod/Classes/SEGFacebookAppEventsIntegration.m
@@ -1,6 +1,11 @@
 #import "SEGFacebookAppEventsIntegration.h"
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
+#else
+#import <Segment/SEGAnalyticsUtils.h>
+#endif
 
 @implementation SEGFacebookAppEventsIntegration
 

--- a/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
 #else
 #import <Segment/SEGIntegrationFactory.h>

--- a/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
+++ b/Pod/Classes/SEGFacebookAppEventsIntegrationFactory.h
@@ -1,5 +1,10 @@
 #import <Foundation/Foundation.h>
+
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGFacebookAppEventsIntegrationFactory : NSObject<SEGIntegrationFactory>
 


### PR DESCRIPTION
https://paper.dropbox.com/doc/PRD-Analytics-iOS-Namespace-Change--A89lGjxWJiMUgRtRmVL5aN1UAg-FewzU7P1dJM5yKVEgfenA

Segment’s iOS SDK was namespaced to SEGAnalytics under the Objective-C naming convention. As we modernized the SDK to support Swift and more package managers beyond Cocoapods such as Swift Package Manager and Carthage the namespace was renamed to Analytics  in-line with Swift idioms as well as Package Manager requirements. It was released as beta. We have received customer feedback that this is leading to namespace collisions and are now going to change this to a much clearer namespace: Segment and the community prefer this as well.